### PR TITLE
fix: update podspec to support integration of rudder minor versions

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ inhibit_all_warnings!
 platform :ios, '15.0'
 
 def shared_pods
-    pod 'Rudder', '~> 2.0.0'
+    pod 'Rudder', '~> 2.0'
 end
 
 target 'RudderIntercom' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - Intercom (17.2.1)
-  - Rudder (2.0.1)
+  - Rudder (2.4.3)
   - RudderIntercom (1.0.0):
     - Intercom (= 17.2.1)
-    - Rudder (~> 2.0.0)
+    - Rudder (~> 2.0)
 
 DEPENDENCIES:
-  - Rudder (~> 2.0.0)
+  - Rudder (~> 2.0)
   - RudderIntercom (from `.`)
 
 SPEC REPOS:
@@ -20,9 +20,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Intercom: 3e9e26c8e2d0655e8f7527c395e570bb7733d5fa
-  Rudder: 463af33116984b97f2a19d344e9ad491f164e43e
-  RudderIntercom: c8b236b78d37422430284f078b824f5bc3768727
+  Rudder: 6d2c0775d5b606e05e00670615ee7f9c0c6d2813
+  RudderIntercom: 53f5939bb275a61b7b87ee3e425329bfa724c199
 
-PODFILE CHECKSUM: be822288d1e6c4e8f08395d884307a433cb1c4df
+PODFILE CHECKSUM: 7a7e5f0365743c030f0824caa703c3341a41cd37
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/RudderIntercom.podspec
+++ b/RudderIntercom.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.
     DESC
     s.homepage         = 'https://github.com/rudderlabs/rudder-integration-intercom-swift'
-    s.license          = { :type => "Apache", :file => "LICENSE.md" }
+    s.license          = { :type => "Elastic", :file => "LICENSE.md" }
     s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
     s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-intercom-swift.git', :tag => "v#{s.version}" }
 
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     s.module_name = 'RudderIntercom'
     s.swift_version = '5.3'
 
-    s.dependency 'Rudder', '~> 2.0.0'
+    s.dependency 'Rudder', '~> 2.0'
     s.dependency 'Intercom', '17.2.1'
 end

--- a/RudderIntercom.podspec
+++ b/RudderIntercom.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'RudderIntercom'
-    s.version          = '1.0.0'
+    s.version          = '1.0.1'
     s.summary          = 'Privacy and Security focused Segment-alternative. Intercom Native SDK integration support.'
     s.description      = <<-DESC
     Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.

--- a/RudderIntercom.xcodeproj/project.pbxproj
+++ b/RudderIntercom.xcodeproj/project.pbxproj
@@ -14,11 +14,11 @@
 
 /* Begin PBXFileReference section */
 		32A1046DB51DF5B025129AD0 /* Pods-RudderIntercom.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderIntercom.debug.xcconfig"; path = "Target Support Files/Pods-RudderIntercom/Pods-RudderIntercom.debug.xcconfig"; sourceTree = "<group>"; };
+		5388D59E2D0A0294000966AB /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		9CE17C2CCA82F2A8D2B93AE9 /* Pods_RudderIntercom.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderIntercom.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA7D5A93759CD6674ACCB0EF /* Pods-RudderIntercom.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderIntercom.release.xcconfig"; path = "Target Support Files/Pods-RudderIntercom/Pods-RudderIntercom.release.xcconfig"; sourceTree = "<group>"; };
 		ED2A28EB2770560400646788 /* RudderIntercom.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RudderIntercom.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED2A28F72770570400646788 /* RudderIntercom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RudderIntercom.h; sourceTree = "<group>"; };
-		ED2A28FA2770591E00646788 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		ED2A28FC2770591E00646788 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		ED2A28FD2770591E00646788 /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		EDC132B127D9DBF400AFD833 /* RudderIntercom.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = RudderIntercom.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -57,8 +57,8 @@
 		ED2A28E12770560400646788 = {
 			isa = PBXGroup;
 			children = (
-				ED2A28FA2770591E00646788 /* LICENSE */,
 				ED2A28FD2770591E00646788 /* Podfile */,
+				5388D59E2D0A0294000966AB /* LICENSE.md */,
 				ED2A28FC2770591E00646788 /* README.md */,
 				EDC132B127D9DBF400AFD833 /* RudderIntercom.podspec */,
 				ED2A28F52770570400646788 /* Sources */,


### PR DESCRIPTION
## Description
This is used to release the fix version of intercom package.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [ ] Version updated in `README`
- [ ] Version updated in `RSConstant.swift`
- [ ] Version updated in `RudderStack.xcodeproj`
- [ ] Version updated in `RudderStack.podspec`
- [x] `CHANGELOG` Updated
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
- [ ] Passed `pod lib lint --no-clean --allow-warnings`
